### PR TITLE
Instantly move to photo location

### DIFF
--- a/public/assets/drag-and-drop.js
+++ b/public/assets/drag-and-drop.js
@@ -45,7 +45,7 @@ function readURL(input) {
                     );
                     $('#lat').val(lat);
                     $('#long').val(long);
-                    map.flyTo([lat, long], 18);
+                    map.setView([lat, long], 18);
                     marker = L.marker([lat, long]).addTo(map);
                     console.log(`lat: ${lat}, long: ${long}`);
                 });


### PR DESCRIPTION
I'm tired of waiting 5 seconds after dropping a photo just to see where it is on the map.
The zoom animation is useless because the map is entirely blue from all the markers.  
The `setView` function is instant.